### PR TITLE
feat(api): add apigateway models for createLocker and updateLocker

### DIFF
--- a/aws-backend/infrastructure/api-gateway-lambdas/api-lambdas-stack.yaml
+++ b/aws-backend/infrastructure/api-gateway-lambdas/api-lambdas-stack.yaml
@@ -216,6 +216,67 @@ Resources:
                 Action: "*"
                 Resource: "*"
 
+  # Model definition for CreateLocker requests
+  # This enforces that every POST /lockers request body must follow this schema
+  # - Requires lockerId, location, and status
+  # - lockerId: alphanumeric string with length between 3–36
+  # - location: string with length between 3–100
+  # - status: must be either "active" or "inactive"
+  # - Rejects any additional/unexpected properties
+  CreateLockerModel:
+    Type: AWS::ApiGateway::Model
+    Properties:
+      RestApiId: !Ref SmartLockerApiGateway
+      ContentType: application/json
+      Name: CreateLockerModel
+      Schema:
+        $schema: "http://json-schema.org/draft-04/schema#"
+        title: "CreateLockerRequest"
+        type: "object"
+        properties:
+          lockerId:
+            type: "string"
+            pattern: "^[a-zA-Z0-9_-]+$"
+            minLength: 3
+            maxLength: 36
+          location:
+            type: "string"
+            minLength: 3
+            maxLength: 100
+          status:
+            type: "string"
+            enum: ["active", "inactive"]
+        required: ["lockerId", "location", "status"]
+        additionalProperties: false
+
+  # Model definition for UpdateLocker requests
+  # This enforces that every PUT /lockers/{id} request body must follow this schema
+  # - Allows updating only location and/or status
+  # - location: string with length between 3–100
+  # - status: must be either "active" or "inactive"
+  # - Rejects any additional/unexpected properties
+  # - At least one property must be present (minProperties: 1)
+  UpdateLockerModel:
+    Type: AWS::ApiGateway::Model
+    Properties:
+      RestApiId: !Ref SmartLockerApiGateway
+      ContentType: application/json
+      Name: UpdateLockerModel
+      Schema:
+        $schema: "http://json-schema.org/draft-04/schema#"
+        title: "UpdateLockerRequest"
+        type: "object"
+        properties:
+          location:
+            type: "string"
+            minLength: 3
+            maxLength: 100
+          status:
+            type: "string"
+            enum: ["active", "inactive"]
+        additionalProperties: false
+        minProperties: 1
+
   ###
   CreateLockerLambda:
     Type: AWS::Serverless::Function
@@ -238,6 +299,11 @@ Resources:
             RestApiId: !Ref SmartLockerApiGateway
             Path: /lockers
             Method: POST # Exposes this Lambda through API Gateway (POST /lockers)
+            RequestModel:
+              Model: !Ref CreateLockerModel  # Enforces schema validation for request body against CreateLockerModel
+              Required: true                 # Ensures a request body must always be present (rejects empty bodies)
+              ContentType: application/json  # Validates that requests use JSON format (rejects other content types)
+
 
   # Explicit log group for Lambda
   # - Retention is set to 14 days to reduce costs and avoid keeping unnecessary logs.
@@ -331,6 +397,10 @@ Resources:
             RestApiId: !Ref SmartLockerApiGateway
             Path: /lockers/{id}
             Method: PUT
+            RequestModel:
+              Model: !Ref UpdateLockerModel  # Enforces schema validation for request body against UpdateLockerModel
+              Required: true                 # Ensures a request body must always be present (rejects empty bodies)
+              ContentType: application/json  # Validates that requests use JSON format (rejects other content types)
 
   UpdateLockerLambdaLogGroup:
     Type: AWS::Logs::LogGroup

--- a/aws-backend/infrastructure/api-gateway-lambdas/api-lambdas-stack.yaml
+++ b/aws-backend/infrastructure/api-gateway-lambdas/api-lambdas-stack.yaml
@@ -216,67 +216,6 @@ Resources:
                 Action: "*"
                 Resource: "*"
 
-  # Model definition for CreateLocker requests
-  # This enforces that every POST /lockers request body must follow this schema
-  # - Requires lockerId, location, and status
-  # - lockerId: alphanumeric string with length between 3–36
-  # - location: string with length between 3–100
-  # - status: must be either "active" or "inactive"
-  # - Rejects any additional/unexpected properties
-  CreateLockerModel:
-    Type: AWS::ApiGateway::Model
-    Properties:
-      RestApiId: !Ref SmartLockerApiGateway
-      ContentType: application/json
-      Name: CreateLockerModel
-      Schema:
-        $schema: "http://json-schema.org/draft-04/schema#"
-        title: "CreateLockerRequest"
-        type: "object"
-        properties:
-          lockerId:
-            type: "string"
-            pattern: "^[a-zA-Z0-9_-]+$"
-            minLength: 3
-            maxLength: 36
-          location:
-            type: "string"
-            minLength: 3
-            maxLength: 100
-          status:
-            type: "string"
-            enum: ["active", "inactive"]
-        required: ["lockerId", "location", "status"]
-        additionalProperties: false
-
-  # Model definition for UpdateLocker requests
-  # This enforces that every PUT /lockers/{id} request body must follow this schema
-  # - Allows updating only location and/or status
-  # - location: string with length between 3–100
-  # - status: must be either "active" or "inactive"
-  # - Rejects any additional/unexpected properties
-  # - At least one property must be present (minProperties: 1)
-  UpdateLockerModel:
-    Type: AWS::ApiGateway::Model
-    Properties:
-      RestApiId: !Ref SmartLockerApiGateway
-      ContentType: application/json
-      Name: UpdateLockerModel
-      Schema:
-        $schema: "http://json-schema.org/draft-04/schema#"
-        title: "UpdateLockerRequest"
-        type: "object"
-        properties:
-          location:
-            type: "string"
-            minLength: 3
-            maxLength: 100
-          status:
-            type: "string"
-            enum: ["active", "inactive"]
-        additionalProperties: false
-        minProperties: 1
-
   ###
   CreateLockerLambda:
     Type: AWS::Serverless::Function
@@ -299,11 +238,6 @@ Resources:
             RestApiId: !Ref SmartLockerApiGateway
             Path: /lockers
             Method: POST # Exposes this Lambda through API Gateway (POST /lockers)
-            RequestModel:
-              Model: !Ref CreateLockerModel  # Enforces schema validation for request body against CreateLockerModel
-              Required: true                 # Ensures a request body must always be present (rejects empty bodies)
-              ContentType: application/json  # Validates that requests use JSON format (rejects other content types)
-
 
   # Explicit log group for Lambda
   # - Retention is set to 14 days to reduce costs and avoid keeping unnecessary logs.
@@ -397,10 +331,6 @@ Resources:
             RestApiId: !Ref SmartLockerApiGateway
             Path: /lockers/{id}
             Method: PUT
-            RequestModel:
-              Model: !Ref UpdateLockerModel  # Enforces schema validation for request body against UpdateLockerModel
-              Required: true                 # Ensures a request body must always be present (rejects empty bodies)
-              ContentType: application/json  # Validates that requests use JSON format (rejects other content types)
 
   UpdateLockerLambdaLogGroup:
     Type: AWS::Logs::LogGroup

--- a/aws-backend/infrastructure/api-gateway-lambdas/api-lambdas-stack.yaml
+++ b/aws-backend/infrastructure/api-gateway-lambdas/api-lambdas-stack.yaml
@@ -53,7 +53,7 @@ Resources:
         openapi: "3.0.3"
         info:
           title: "SmartLocker API"
-          version: "1.0.0"
+          version: "1.1.0"
         paths:
           /lockers:
             post:

--- a/aws-backend/infrastructure/api-gateway-lambdas/api-lambdas-stack.yaml
+++ b/aws-backend/infrastructure/api-gateway-lambdas/api-lambdas-stack.yaml
@@ -53,7 +53,7 @@ Resources:
         openapi: "3.0.3"
         info:
           title: "SmartLocker API"
-          version: "1.1.0"
+          version: "1.2.0"
         paths:
           /lockers:
             post:

--- a/aws-backend/infrastructure/api-gateway-lambdas/api-lambdas-stack.yaml
+++ b/aws-backend/infrastructure/api-gateway-lambdas/api-lambdas-stack.yaml
@@ -53,7 +53,7 @@ Resources:
         openapi: "3.0.3"
         info:
           title: "SmartLocker API"
-          version: "1.3.0"
+          version: "1.4.0"
         paths:
           /lockers:
             post:

--- a/aws-backend/infrastructure/api-gateway-lambdas/api-lambdas-stack.yaml
+++ b/aws-backend/infrastructure/api-gateway-lambdas/api-lambdas-stack.yaml
@@ -53,7 +53,7 @@ Resources:
         openapi: "3.0.3"
         info:
           title: "SmartLocker API"
-          version: "1.2.0"
+          version: "1.3.0"
         paths:
           /lockers:
             post:

--- a/aws-backend/infrastructure/api-gateway-lambdas/openapi/smartlocker-apis-oas30.yaml
+++ b/aws-backend/infrastructure/api-gateway-lambdas/openapi/smartlocker-apis-oas30.yaml
@@ -7,9 +7,15 @@ info:
 security:
   - CognitoAuthorizer: []
 
+x-amazon-apigateway-request-validators:
+  all:
+    validateRequestBody: true
+    validateRequestParameters: true
+
 paths:
   /lockers:
     post:
+      x-amazon-apigateway-request-validator: all
       parameters:
         - name: Content-Type
           in: header
@@ -71,6 +77,7 @@ paths:
             statusCode: "200"
 
     put:
+      x-amazon-apigateway-request-validator: all
       parameters:
         - name: id
           in: path

--- a/aws-backend/infrastructure/api-gateway-lambdas/openapi/smartlocker-apis-oas30.yaml
+++ b/aws-backend/infrastructure/api-gateway-lambdas/openapi/smartlocker-apis-oas30.yaml
@@ -11,6 +11,16 @@ x-amazon-apigateway-request-validators:
   all:
     validateRequestBody: true
     validateRequestParameters: true
+    
+x-amazon-apigateway-models:
+  CreateLockerRequest:
+    contentType: application/json
+    schema: 
+      $ref: "#/components/schemas/CreateLockerRequest"
+  UpdateLockerRequest:
+    contentType: application/json
+    schema:
+      $ref: "#/components/schemas/UpdateLockerRequest"
 
 paths:
   /lockers:

--- a/aws-backend/infrastructure/api-gateway-lambdas/openapi/smartlocker-apis-oas30.yaml
+++ b/aws-backend/infrastructure/api-gateway-lambdas/openapi/smartlocker-apis-oas30.yaml
@@ -20,7 +20,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/CreateLockerRequest"
         required: true
       responses:
         "200":
@@ -41,7 +41,7 @@ paths:
             description: "200 response"
         x-amazon-apigateway-integration:
           type: aws_proxy
-          httpMethod: GET
+          httpMethod: POST
           uri: !Sub >
             arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:list-lockers-${EnvironmentKey}/invocations
           responses:
@@ -81,7 +81,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
+              $ref: "#/components/schemas/UpdateLockerRequest"
       responses:
         "200":
           description: "Locker updated"
@@ -118,6 +118,42 @@ paths:
             statusCode: "204"
 
 components:
+  schemas:
+    # Model definition for CreateLocker requests
+    # This enforces that every POST /lockers request body must follow this schema
+    CreateLockerRequest:
+      type: object
+      properties:
+        lockerId:
+          type: string
+          pattern: "^[a-zA-Z0-9_-]+$"
+          minLength: 3
+          maxLength: 36
+        location:
+          type: string
+          minLength: 3
+          maxLength: 100
+        status:
+          type: string
+          enum: ["active", "inactive"]
+      required: ["lockerId", "location", "status"]
+      additionalProperties: false
+
+    # Model definition for UpdateLocker requests
+    # This enforces that every PUT /lockers/{id} request body must follow this schema
+    UpdateLockerRequest:
+      type: object
+      properties:
+        location:
+          type: string
+          minLength: 3
+          maxLength: 100
+        status:
+          type: string
+          enum: ["active", "inactive"]
+      additionalProperties: false
+      minProperties: 1
+
   securitySchemes:
     CognitoAuthorizer:
       type: apiKey

--- a/aws-backend/infrastructure/api-gateway-lambdas/openapi/smartlocker-apis-oas30.yaml
+++ b/aws-backend/infrastructure/api-gateway-lambdas/openapi/smartlocker-apis-oas30.yaml
@@ -16,6 +16,8 @@ paths:
   /lockers:
     post:
       x-amazon-apigateway-request-validator: all
+      x-amazon-apigateway-request-models:
+        application/json: CreateLockerRequest 
       parameters:
         - name: Content-Type
           in: header
@@ -78,6 +80,8 @@ paths:
 
     put:
       x-amazon-apigateway-request-validator: all
+      x-amazon-apigateway-request-models:
+        application/json: UpdateLockerRequest
       parameters:
         - name: id
           in: path


### PR DESCRIPTION
This PR improves the SmartLocker API Gateway configuration by introducing request models to enforce strict validation of incoming payloads.

API Gateway Models

- CreateLockerModel
  - Requires lockerId, location, and status.
  - Validates lockerId format (^[a-zA-Z0-9_-]+$, 3–36 chars).
  - Validates location length (3–100 chars).
  - Restricts status to active | inactive.
  - Rejects additional/unexpected properties.

- UpdateLockerModel
  - Allows updating location and/or status.
  - Requires at least one field (minProperties: 1).
  - Validates location length (3–100 chars).
  - Restricts status to active | inactive.
  - Rejects additional/unexpected properties.


Lambda Event Configuration
- Linked CreateLockerLambda to CreateLockerModel.
- Linked UpdateLockerLambda to UpdateLockerModel.
- Enforced:
  - Required: true → request body cannot be empty.
  - ContentType: application/json → only JSON payloads are accepted.